### PR TITLE
Speed up module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     ]
   },
   "dependencies": {
+    "alphanum-sort": "^1.0.2",
     "app-root-path": "^3.0.0",
     "enhanced-resolve": "^5.7.0",
     "fast-glob": "^3.2.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,17 @@
 const path = require('path');
+const fs = require('fs');
 const packageJsonFinder = require('find-package-json');
 
-const { createMemoisedResolver } = require('./resolver');
-const { getDuplicatedPackages } = require('./utils');
+const {createMemoisedResolver} = require('./resolver');
+const {getDuplicatedPackages} = require('./utils');
+const {buildSearchTrie, searchTrie} = require('./trie');
+const {readPackageName} = require('./package-utils');
 
 const containsNodeModules = (resolvedResource) => {
     return resolvedResource.includes('node_modules');
 };
+
+const {sep} = path;
 
 const findDuplicate = (resolvedResource) => (duplicate) => {
     // prevent partial name matches. I.e. don't match `/button` when resolving `/button-group`
@@ -18,7 +23,71 @@ const findBestMatch = (arr, matcher) => {
     return arr.filter(matcher).sort((a, b) => b.length - a.length)[0];
 };
 
-const deduplicate = (result, dupVals, resolver) => {
+const getPackageName = function (trie, location) {
+    const {path: packageLocation} = searchTrie(trie, location, sep);
+    // trie contains package.json locations. Just look for one
+    return readPackageName(packageLocation);
+};
+
+const oldSearch = (dupVals, resolvedResource) => {
+    for(const onePackageDuplicates of dupVals) {
+        const found = findBestMatch(onePackageDuplicates, findDuplicate(resolvedResource));
+
+        if (!found) {
+            continue;
+        }
+
+        const replaceWithFirst = onePackageDuplicates[0];
+        const resolvedDup = resolvedResource.replace(found, replaceWithFirst);
+
+        const lastIndex = resolvedDup.indexOf(
+            'node_modules',
+            resolvedDup.indexOf(replaceWithFirst) + replaceWithFirst.length
+        );
+
+        if (lastIndex !== -1) {
+            continue;
+        }
+
+        const resolvedBase = packageJsonFinder(resolvedDup).next().value;
+        const resolvedResourceBase = packageJsonFinder(resolvedResource).next().value;
+
+        if (resolvedBase.version !== resolvedResourceBase.version) {
+            console.error('ooof');
+            throw new Error('package version mismatch')
+        }
+
+        if(resolvedResource===resolvedDup){
+            return undefined;
+        }
+
+        return resolvedDup;
+    };
+}
+
+const newSearch = (trie, resolvedResource) => {
+    const { value: replaceWithFirst, path: found } = searchTrie(trie, resolvedResource, sep);
+
+    // found record in trie, and it's not already optimal
+    // however it's guaranteed to be "maximal"
+    if (!replaceWithFirst || found === replaceWithFirst) {
+        return undefined;
+    }
+
+    const resolvedDup = resolvedResource.replace(found, replaceWithFirst)
+    const lastIndex = resolvedDup.indexOf(
+        'node_modules',
+        replaceWithFirst.length
+    );
+
+    if (lastIndex !== -1) {
+        return undefined;
+    }
+    // replacing path by alias
+    return resolvedDup;
+}
+
+const deduplicate = (result, dupVals, trie, resolver, replacements) => {
     // Note that the "API" for a beforeResolve hook is to return `undefined` to continue,
     // or `false` to skip this dependency. So we pretty much always return `undefined`.
 
@@ -39,49 +108,43 @@ const deduplicate = (result, dupVals, resolver) => {
         return undefined;
     }
 
-    // we will change result as a side-effect
-    dupVals.some((onePackageDuplicates) => {
-        const found = findBestMatch(onePackageDuplicates, findDuplicate(resolvedResource));
+    const v1 = oldSearch(dupVals, resolvedResource);
+    const v2 = newSearch(trie, resolvedResource);
 
-        if (!found) {
-            return false;
-        }
-
-        const replaceWithFirst = onePackageDuplicates[0];
-        const resolvedDup = resolvedResource.replace(found, replaceWithFirst);
-
-        const lastIndex = resolvedDup.indexOf(
-            'node_modules',
-            resolvedDup.indexOf(replaceWithFirst) + replaceWithFirst.length
-        );
-
-        if (lastIndex !== -1) {
-            return false;
-        }
-
-        const resolvedBase = packageJsonFinder(resolvedDup).next().value.name;
-        const resolvedResourceBase = packageJsonFinder(resolvedResource).next().value.name;
-        if (resolvedBase !== resolvedResourceBase) {
-            return false;
-        }
-
-        // this is how it works with webpack
-        // eslint-disable-next-line no-param-reassign
-        result.request = resolvedDup;
-        return true;
-    });
+    if(v1!==v2){
+        console.error('mismatch', resolvedResource,v1,v2)
+        throw new Error(`${resolvedResource}: ${v1} -> ${v2}`)
+    }
+    if(v2){
+        // replacements[resolvedResource] = v2;
+        result.request = v1;
+    }
 
     return undefined;
 };
 
+/**
+ * creates a search trie in form of [path]->[shortest variant]
+ */
+const prepareDuplicationDictionary = (duplicates) => {
+    const load = [];
+    duplicates.forEach((candidates) => {
+        const bestChoice = candidates[0];
+        candidates.forEach((packagePath) => {
+            load.push([packagePath, bestChoice]);
+        });
+    });
+    return buildSearchTrie(load, sep);
+};
+
 class WebpackDeduplicationPlugin {
-    constructor({ cacheDir, rootPath }) {
+    constructor({cacheDir, rootPath}) {
         this.cacheDir = cacheDir;
         this.rootPath = rootPath;
     }
 
     apply(compiler) {
-        const { cacheDir, rootPath } = this;
+        const {cacheDir, rootPath} = this;
         const duplicates = getDuplicatedPackages({
             cacheDir,
             rootPath,
@@ -90,11 +153,20 @@ class WebpackDeduplicationPlugin {
         const resolver = createMemoisedResolver(compiler.options.resolve.mainFields);
 
         const dupVals = Object.values(duplicates);
+        const trie = prepareDuplicationDictionary(dupVals);
+
+        const replacements = {};
         compiler.hooks.normalModuleFactory.tap('WebpackDeduplicationPlugin', (nmf) => {
             nmf.hooks.beforeResolve.tap('WebpackDeduplicationPlugin', (result) => {
-                return deduplicate(result, dupVals, resolver);
+                const answer = deduplicate(result, dupVals, trie, resolver, replacements);
+                return answer;
             });
         });
+
+        compiler.hooks.done.tap('WebpackDeduplicationPlugin', () => {
+            console.log('saving stash');
+            // fs.writeFileSync(path.join(cacheDir, 'resolved.json'), JSON.stringify(replacements, null, 2));
+        })
     }
 }
 

--- a/src/package-utils.js
+++ b/src/package-utils.js
@@ -1,0 +1,12 @@
+const { readFileSync } = require('fs');
+const { join } = require('path');
+const memoize = require('lodash/memoize');
+
+const readPackageName = memoize(function (location) {
+    const data = readFileSync(join(location, 'package.json'), 'UTF-8');
+    return JSON.parse(data).name;
+});
+
+module.exports = {
+    readPackageName,
+};

--- a/src/trie.js
+++ b/src/trie.js
@@ -1,0 +1,53 @@
+const VALUE = Symbol('value');
+
+/**
+ * Created search trie
+ * @param {string[][]} lines
+ * @example
+ *  buildSearchTrie([
+ *   ['path1','value1'],
+ *   ['path1.path2','value2'],
+ *  ]);
+ */
+export const buildSearchTrie = (lines, separator = '/') => {
+    const root = {};
+    for (let i = 0; i < lines.length; ++i) {
+        const path = lines[i][0].split(separator);
+        let node = root;
+        // const lastIndex = path.length - 1;
+        for (let j = 0; j < path.length; ++j) {
+            const item = path[j];
+            if (!node[item]) {
+                node[item] = {};
+            }
+            node = node[item];
+        }
+        node[VALUE] = lines[i][1];
+    }
+    return root;
+};
+
+export const searchTrie = (trie, path, separator = '/') => {
+    let node = trie;
+    let lastValue = undefined;
+    let lastValuePath = -1;
+    let valuePath = [];
+    const paths = path.split(separator);
+
+    for (let i = 0; i < paths.length; ++i) {
+        node = node[paths[i]];
+        if (!node) {
+            break;
+        }
+        valuePath.push(paths[i]);
+        if (node[VALUE]) {
+            lastValue = node[VALUE];
+            lastValuePath = i;
+        }
+    }
+
+    return {
+        value: lastValue,
+        path: valuePath.slice(0, lastValuePath + 1).join(separator),
+    };
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const alphaSort = require('alphanum-sort');
 const appRoot = require('app-root-path');
 const glob = require('fast-glob');
 const flatten = require('lodash/flatten');
@@ -70,6 +71,12 @@ const getCacheKey = ({ patchedPackages, rootPath }) => {
 const filterOnlyDuplicates = (pkg) =>
     pkg.split(path.sep).filter((p) => p === 'node_modules').length > 1;
 
+const resortNames = (duplicates) =>
+    alphaSort(Object.keys(duplicates)).reduce((acc, item) => {
+        acc[item] = duplicates[item].sort((a, b) => a.length - b.length);
+        return acc;
+    }, {});
+
 const CACHE_BUST = 1;
 
 const getDuplicatedPackages = (options = {}) => {
@@ -115,13 +122,15 @@ const getDuplicatedPackages = (options = {}) => {
         return value.length > 1 && !patchedPackages.includes(key);
     });
 
-    const cleanFromFalsePositives = transform(
-        onlyDuplicates,
-        (result, value, key) => {
-            // eslint-disable-next-line no-param-reassign
-            result[key] = extractProperDuplicates(value).sort();
-        },
-        {}
+    const cleanFromFalsePositives = resortNames(
+        transform(
+            onlyDuplicates,
+            (result, value, key) => {
+                // eslint-disable-next-line no-param-reassign
+                result[key] = extractProperDuplicates(value).sort();
+            },
+            {}
+        )
     );
 
     if (cacheFileName) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,6 +1208,11 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+alphanum-sort@^1.0.2:
+  version "1.0.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
+  integrity sha512-0FcBfdcmaumGPQ0qPn7Q5qTgz/ooXgIyp1rf8ik5bGX8mpE2YHjC0P/eyQvxu1GURYQgq9ozf2mteQ5ZD9YiyQ==
+
 ansi-escapes@^4.2.1:
   version "4.3.1"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"


### PR DESCRIPTION
This PR improves two moments:
- it presorts `cache` file, so there is no need to do it every time, as well sorts package names so the file is more readable. Key's might be not really needed, but why not?
- it changes the resolution algorithm 
 - from array search `O(files*duplicates*pathlen)`
 - to trie search `O(files * pathlen)`. Which (in my test case) is 2000 times faster (not measured in real).

Trie also provides:
- stable access to the "folders" - it will always find the longest match in terms of folders, not characters
- list of all `package.jsons`. See comments below.