### PR TITLE
Fix #14 where the plugin is incorrectly replacing a prefix of another unrelated package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ npm-debug.log*
 # Editors
 .idea
 .vscode
+.history
 *.iml
 .vs
 jsconfig.json

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "build:js": "babel src --out-dir build --extensions \".ts,.tsx,.js\" --ignore src/__tests__ --source-maps inline",
     "lint": "eslint --ext .ts,.tsx,.js src/"
   },
+  "jest": {
+    "roots": ["src"]
+  },
   "dependencies": {
     "app-root-path": "^3.0.0",
     "browser-resolve": "^1.11.3",

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -108,7 +108,7 @@ describe('duplicate-transitive-replacement', () => {
 
         const res = deduplicate(matchingResource, duplicates);
 
-        expect(res).toBeFalsy()
+        expect(res).toBeFalsy();
     });
 
     it('duplicate transitive dependencies replacement - non-matching duplicates should return undefined', () => {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -69,31 +69,38 @@ describe('duplicate-transitive-replacement', () => {
         );
     });
 
-    it('should not mistakenly replace prefix string', () => {
+    it('should not deduplicate when package name is partial match', () => {
         mockFs({
             [path.resolve(
-                'node_modules/@atlaskit/foo/node_modules/@atlaskit/bar',
-                './something'
-            )]: 'stuff',
+                'node_modules/@org/component-a/node_modules/@org/radio-button',
+                './index.js'
+            )]: 'some radio button code',
+
             [path.resolve(
-                'node_modules/@atlaskit/zoo/node_modules/@atlaskit/bar',
-                './something'
-            )]: 'stuff',
+                'node_modules/@org/component-b/node_modules/@org/radio-button',
+                './index.js'
+            )]: 'some radio button code',
+
             [path.resolve(
-                'node_modules/@atlaskit/zoo/node_modules/@atlaskit/barrr',
-                './something-else'
-            )]: 'other stuff',
+                'node_modules/@org/component-b/node_modules/@org/radio-button-group',
+                './index.js'
+            )]: 'some radio button GROUP code',
         });
+
         const duplicates = [
+            // although duplicate packages are prefixed with 'radio-button', these should
+            // be ignored as they are not a full match on the 'radio-button-group'
             [
-                'node_modules/@atlaskit/foo/node_modules/@atlaskit/bar',
-                'node_modules/@atlaskit/zoo/node_modules/@atlaskit/bar',
+                'node_modules/@org/component-a/node_modules/@org/radio-button',
+                'node_modules/@org/component-b/node_modules/@org/radio-button',
             ],
         ];
 
         const matchingResource = mockResource({
-            filename: './something-else',
-            context: path.resolve('node_modules/@atlaskit/zoo/node_modules/@atlaskit/barrr'),
+            filename: './index.js',
+            context: path.resolve(
+                'node_modules/@org/component-b/node_modules/@org/radio-button-group'
+            ),
         });
 
         silent.mockImplementation(() =>
@@ -103,7 +110,7 @@ describe('duplicate-transitive-replacement', () => {
         const finder = require('find-package-json');
 
         finder.mockImplementation(() => ({
-            next: () => ({ value: { name: '@atlaskit/zoo' } }),
+            next: () => ({ value: { name: '@org/component-b' } }),
         }));
 
         const res = deduplicate(matchingResource, duplicates);

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ const containsNodeModules = (resolvedResource) => {
 };
 
 const findDuplicate = (res) => (t) => {
-    return res.includes(t);
+    return res.includes(t + '/');
 };
 
 const findBestMatch = (arr, matcher) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const browserResolve = require('browser-resolve');
 const packageJsonFinder = require('find-package-json');
 const memoize = require('lodash/memoize');
@@ -75,8 +76,10 @@ const containsNodeModules = (resolvedResource) => {
     return resolvedResource.includes('node_modules');
 };
 
-const findDuplicate = (res) => (t) => {
-    return res.includes(t + '/');
+const findDuplicate = (resolvedResource) => (duplicate) => {
+    // prevent partial name matches. I.e. don't match `/button` when resolving `/button-group`
+    const duplicateDir = `${duplicate}${path.sep}`;
+    return resolvedResource.includes(duplicateDir);
 };
 
 const findBestMatch = (arr, matcher) => {


### PR DESCRIPTION
The plugin was incorrectly replacing the prefix of `node_modules/@atlassian/ptc-embeddable-directory/node_modules/@atlaskit/avatar-group/dist/cjs/index.d.ts` when deduplicating `node_modules/@atlassian/ptc-embeddable-directory/node_modules/@atlaskit/avatar`


